### PR TITLE
feat: add phone field to candidate creation

### DIFF
--- a/app/models/services/CandidateServices.js
+++ b/app/models/services/CandidateServices.js
@@ -129,6 +129,7 @@ export const createCandidate = async (candidate) => {
     const {
         name,
         email,
+        phone,
         date_of_birth,
         occupation,
         summary,
@@ -143,6 +144,7 @@ export const createCandidate = async (candidate) => {
         const [candidateInstance, created] = await Candidate.upsert({
             name: name || null,
             email: email || null,
+            phone: phone || null,
             date_of_birth: date_of_birth || null,
             occupation: occupation || null,
             summary: summary || null,


### PR DESCRIPTION
This pull request makes a small update to the candidate creation service by adding support for a `phone` field. The `createCandidate` function now accepts and stores a candidate's phone number.

* Added `phone` to the destructured fields in the `createCandidate` function and included it in the `Candidate.upsert` call to ensure the phone number is saved when creating or updating a candidate. [[1]](diffhunk://#diff-ee040cb74c902f29d94e8f4908d21ae7d65884dfa748a39b49080de39e198913R132) [[2]](diffhunk://#diff-ee040cb74c902f29d94e8f4908d21ae7d65884dfa748a39b49080de39e198913R147)