### PR TITLE
feat(schema): add foreign key and unique constraint to candidate_shar…

### DIFF
--- a/DB/Schema.sql
+++ b/DB/Schema.sql
@@ -56,17 +56,13 @@ CREATE TABLE IF NOT EXISTS candidate_shares (
     candidate_id INT,
     sender_id INT,
     receiver_id INT,
+    application_id INT,
     status ENUM('pending','accepted','rejected') DEFAULT 'pending',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (candidate_id) REFERENCES candidates(candidate_id) ON DELETE SET NULL,
     FOREIGN KEY (sender_id) REFERENCES users(user_id) ON DELETE SET NULL,
-    FOREIGN KEY (receiver_id) REFERENCES users(user_id) ON DELETE SET NULL
+    FOREIGN KEY (receiver_id) REFERENCES users(user_id) ON DELETE SET NULL,
+    FOREIGN KEY (application_id) REFERENCES applications(application_id) ON DELETE SET NULL,
+    UNIQUE (candidate_id, sender_id, receiver_id, application_id)
 );
-
-sender_id      (FK -> users.user_id)     -- quién compartió
-receiver_id    (FK -> users.user_id)     -- quién recibe
-status         (enum: "pending", "accepted", "rejected") 
-created_at
-updated_at
-


### PR DESCRIPTION
This pull request updates the `candidate_shares` table schema to include support for tracking the application associated with each share and to ensure data integrity through new constraints. The most important changes are:

**Schema enhancements:**

* Added a new column `application_id` to the `candidate_shares` table to associate each share with a specific application.
* Added a foreign key constraint on `application_id` referencing the `applications` table, with `ON DELETE SET NULL` to maintain referential integrity.

**Data integrity improvements:**

* Introduced a unique constraint on the combination of `candidate_id`, `sender_id`, `receiver_id`, and `application_id` to prevent duplicate share records for the same candidate and application between the same users.